### PR TITLE
Update URI formats

### DIFF
--- a/ts/generators/coreFormat.ts
+++ b/ts/generators/coreFormat.ts
@@ -8,7 +8,8 @@ var regexps: IStringMap = {
   email: '[a-zA-Z\\d][a-zA-Z\\d-]{1,13}[a-zA-Z\\d]@{hostname}',
   hostname: '[a-zA-Z]{1,33}\\.[a-z]{2,4}',
   ipv6: '[a-f\\d]{4}(:[a-f\\d]{4}){7}',
-  uri: '[a-zA-Z][a-zA-Z0-9+-.]*'
+  uri: 'https?://[a-zA-Z][a-zA-Z0-9+-.]*',
+  uri-reference: '(https?://|#|/|)[a-zA-Z][a-zA-Z0-9+-.]*'
 };
 
 /**


### PR DESCRIPTION
According to [Draft
6](http://json-schema.org/draft-06/json-schema-migration-faq.html#formats-uri-vs-uri-reference),
the `uri` format must only contain absolute URIs, whereas the `uri-reference`
format is more general. This commit makes the `uri` format generator
spec-compliant and also adds the `uri-reference` format (closes #343).